### PR TITLE
ci(github): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Each line is a file pattern followed by one or more owners.
+# See: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customizations/about-code-owners
+
+# Default owners (project contributors with known GitHub handles)
+* @somnio-kimm @Moulru
+
+# Notebooks and datasets
+/code/ @somnio-kimm @Moulru
+/data/ @somnio-kimm @Moulru
+/docs/ @somnio-kimm @Moulru
+
+# CI / meta
+/.github/ @somnio-kimm


### PR DESCRIPTION
## Summary
- Route reviews automatically with contributors as default owners

## Changes
- Add `.github/CODEOWNERS` listing `@somnio-kimm` and `@Moulru`, with path-specific rules for `/code/`, `/data/`, `/docs/`, `/.github/`

## Related Issue
Closes #3

## Notes
- Contributors without GitHub handles documented in README

## Test
- [ ] PR touching `/code/` requests the matching owners
