### PR TITLE
ci(github): add pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,25 @@
+name: pre-commit
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install deps
+        run: uv sync --all-extras --dev
+      - name: Run pre-commit
+        run: uv run pre-commit run --all-files


### PR DESCRIPTION
## Summary
- Run `make pre-commit` in CI

## Changes
- Add `.github/workflows/pre-commit.yml` triggered on pull_request and pushes to `main`/`dev`, using `astral-sh/setup-uv` for cached installs

## Related Issue
Closes #6

## Notes
- Can be a required check on `dev` once pyproject lands

## Test
- [ ] Workflow fails on style violations
