### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do **not** open a public issue for security vulnerabilities.
+
+Report privately via [GitHub's security advisory form](https://github.com/somnio-kimm/antarctic_glacier_analysis/security/advisories/new),
+or email the maintainers directly.
+
+You can expect an initial response within 5 business days.
+
+## Supported Versions
+
+Only the latest release on the default branch receives security fixes.


### PR DESCRIPTION
## Summary
- Private security disclosure path

## Changes
- Add `SECURITY.md` pointing at GitHub's private advisory form

## Related Issue
Closes #13

## Notes
-

## Test
- [ ] Link resolves
