### PR TITLE
chore(repo): add .gitignore and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml,json,md,toml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Byte-compiled
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Environments
+.env
+.venv
+env/
+venv/
+
+# uv
+uv.lock
+
+# Jupyter
+.ipynb_checkpoints/
+
+# Caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.cache
+
+# IDE
+.cursor/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Large image datasets (not stored in git; fetch from NSIDC)
+/data/input/image_orig/
+/data/input/image_resized/
+/data/input/image_grey/


### PR DESCRIPTION
## Summary
- Baseline ignore rules, editor config, and keep large image datasets out of git

## Changes
- Add root `.gitignore` (Python, Jupyter, caches, `.DS_Store`, `/data/input/image_orig/`, `/data/input/image_resized/`, `/data/input/image_grey/`)
- Add root `.editorconfig`

## Related Issue
Closes #15

## Notes
- Raw imagery stays on disk locally but never enters the repo; document fetch flow in README

## Test
- [ ] `git status` stays clean after running notebooks
- [ ] Large image directories are untracked
