### PR TITLE
chore(repo): add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.venv
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.ipynb_checkpoints
+__pycache__
+data
+docs


### PR DESCRIPTION
## Summary
- Exclude caches, data, docs, VCS from Docker builds

## Changes
- Add `.dockerignore`

## Related Issue
Closes #16

## Notes
-

## Test
- [ ] Build context excludes `.git`, `data/`, `docs/`, cache dirs
