### PR TITLE
chore(tooling): add root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: install lint format pre-commit jupyter web clean
+
+install:
+	uv sync --all-extras --dev
+	uv run pre-commit install
+
+lint:
+	uv run ruff check .
+
+format:
+	uv run ruff format .
+	uv run ruff check --fix .
+
+pre-commit:
+	uv run pre-commit run --all-files
+
+jupyter:
+	uv run jupyter lab
+
+web:
+	cd code && unzip -o web.zip -d web && cd web && uv run python app.py
+
+clean:
+	rm -rf .pytest_cache .ruff_cache .mypy_cache build dist *.egg-info
+	find . -type d -name __pycache__ -exec rm -rf {} +
+	find . -type d -name .ipynb_checkpoints -exec rm -rf {} +


### PR DESCRIPTION
## Summary
- Single dev entrypoint

## Changes
- Add root `Makefile` with `install`, `lint`, `format`, `pre-commit`, `jupyter`, `web`, `clean`

## Related Issue
Closes #17

## Notes
- `make web` extracts `code/web.zip` and runs the Flask app

## Test
- [ ] Each target runs from repo root once pyproject lands
